### PR TITLE
Fix public install paths

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,8 +35,6 @@ homebrew_casks:
     directory: Casks
     generate_completions_from_executable:
       executable: "bin/gnb"
-      args:
-        - completion
       shell_parameter_format: cobra
       shells:
         - bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Project config discovery now walks parent directories, so `.ganbatte.*` works from nested repo paths.
 
 ### Fixed
+- Go module path now matches the public `bssm-oss/ganbatte` repository, so `go install github.com/bssm-oss/ganbatte@latest` works.
+- Homebrew cask completion generation no longer passes a duplicate `completion` argument.
 - `gnb run` and `gnb show` now use merged global/project config, matching `gnb list` behavior.
 - `gnb run` now asks for confirmation when a project item overrides a global item unless `--yes` is used.
 - Release workflow now passes the Homebrew tap token using the environment variable expected by GoReleaser.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ go test -run TestMigrate ./...  # 특정 테스트
 
 ## Reporting Bugs
 
-[GitHub Issues](https://github.com/justn-hyeok/ganbatte/issues)에 다음 정보와 함께 등록:
+[GitHub Issues](https://github.com/bssm-oss/ganbatte/issues)에 다음 정보와 함께 등록:
 
 - OS / shell / Go version
 - 재현 단계

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@
 brew install --cask bssm-oss/tap/ganbatte
 
 # Go install (macOS / Linux)
-go install github.com/justn-hyeok/ganbatte@latest
+go install github.com/bssm-oss/ganbatte@latest
 
 # 로컬 빌드
-git clone https://github.com/justn-hyeok/ganbatte.git
+git clone https://github.com/bssm-oss/ganbatte.git
 cd ganbatte
 go build -o gnb .
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@
 
 보안 취약점을 발견하셨다면 **공개 이슈로 등록하지 마시고**, 아래 방법으로 비공개 보고해주세요:
 
-- GitHub Security Advisory: [Report a vulnerability](https://github.com/justn-hyeok/ganbatte/security/advisories/new)
+- GitHub Security Advisory: [Report a vulnerability](https://github.com/bssm-oss/ganbatte/security/advisories/new)
 
 보고 시 포함해주실 내용:
 - 취약점 설명

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/config_convert.go
+++ b/cmd/config_convert.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/config_path.go
+++ b/cmd/config_path.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
-	"github.com/justn-hyeok/ganbatte/internal/shell"
-	"github.com/justn-hyeok/ganbatte/internal/track"
+	"github.com/bssm-oss/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/shell"
+	"github.com/bssm-oss/ganbatte/internal/track"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -7,10 +7,10 @@ import (
 
 func TestFindShellInitLines(t *testing.T) {
 	tests := []struct {
-		name        string
-		lines       []string
-		wantP10k    int
-		wantGnb     int
+		name     string
+		lines    []string
+		wantP10k int
+		wantGnb  int
 	}{
 		{
 			name: "both present, gnb after p10k",

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/gendoc.go
+++ b/cmd/gendoc.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/justn-hyeok/ganbatte/cmd"
+	"github.com/bssm-oss/ganbatte/cmd"
 	"github.com/spf13/cobra/doc"
 )
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/justn-hyeok/ganbatte/internal/shell"
+	"github.com/bssm-oss/ganbatte/internal/shell"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
-	"github.com/justn-hyeok/ganbatte/internal/shell"
+	"github.com/bssm-oss/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/shell"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
-	"github.com/justn-hyeok/ganbatte/internal/tui"
-	"github.com/justn-hyeok/ganbatte/internal/workflow"
+	"github.com/bssm-oss/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/tui"
+	"github.com/bssm-oss/ganbatte/internal/workflow"
 )
 
 // RootCmd represents the base command when called without any subcommands

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
-	"github.com/justn-hyeok/ganbatte/internal/workflow"
+	"github.com/bssm-oss/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/shell_init.go
+++ b/cmd/shell_init.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
-	"github.com/justn-hyeok/ganbatte/internal/shell"
+	"github.com/bssm-oss/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/shell"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/shell_init_test.go
+++ b/cmd/shell_init_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
-	"github.com/justn-hyeok/ganbatte/internal/history"
-	"github.com/justn-hyeok/ganbatte/internal/shell"
-	"github.com/justn-hyeok/ganbatte/internal/track"
+	"github.com/bssm-oss/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/history"
+	"github.com/bssm-oss/ganbatte/internal/shell"
+	"github.com/bssm-oss/ganbatte/internal/track"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/justn-hyeok/ganbatte
+module github.com/bssm-oss/ganbatte
 
 go 1.26.1
 

--- a/internal/history/fish.go
+++ b/internal/history/fish.go
@@ -12,8 +12,8 @@ import (
 // FishParser parses fish shell history files.
 // Format:
 //
-//	- cmd: <command>
-//	  when: <timestamp>
+//   - cmd: <command>
+//     when: <timestamp>
 type FishParser struct{}
 
 // Parse reads a fish history file and returns entries.

--- a/internal/history/suggest_test.go
+++ b/internal/history/suggest_test.go
@@ -15,11 +15,11 @@ func TestIsNoise(t *testing.T) {
 		cmd   string
 		noise bool
 	}{
-		{"ls", true},          // too short (< 4)
-		{"cd ~", false},       // 4 chars exactly
-		{"# comment", true},   // starts with #
+		{"ls", true},            // too short (< 4)
+		{"cd ~", false},         // 4 chars exactly
+		{"# comment", true},     // starts with #
 		{"git status \\", true}, // ends with backslash (continuation)
-		{"}{\\", true},        // all punctuation
+		{"}{\\", true},          // all punctuation
 		{"git status -sb", false},
 		{"npm run build", false},
 		{"   ", true}, // short after we check len(cmd) < 4 (spaces still < 4 meaningful but len("   ")==3)
@@ -36,13 +36,13 @@ func TestIsNoise(t *testing.T) {
 
 func TestIsArgLike(t *testing.T) {
 	// Should be arg-like (true)
-	assert.True(t, isArgLike("github.com/user/repo"))    // contains dot
-	assert.True(t, isArgLike("./src/main.go"))           // contains /
-	assert.True(t, isArgLike("user@host.com"))           // contains @
-	assert.True(t, isArgLike("my-long-package-name"))    // len > 10
-	assert.True(t, isArgLike("MyPackage"))               // uppercase
-	assert.True(t, isArgLike("node123"))                 // has digit
-	assert.True(t, isArgLike("http://example.com"))      // URL
+	assert.True(t, isArgLike("github.com/user/repo")) // contains dot
+	assert.True(t, isArgLike("./src/main.go"))        // contains /
+	assert.True(t, isArgLike("user@host.com"))        // contains @
+	assert.True(t, isArgLike("my-long-package-name")) // len > 10
+	assert.True(t, isArgLike("MyPackage"))            // uppercase
+	assert.True(t, isArgLike("node123"))              // has digit
+	assert.True(t, isArgLike("http://example.com"))   // URL
 
 	// Should NOT be arg-like (subcommand-like)
 	assert.False(t, isArgLike("add"))

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/justn-hyeok/ganbatte/internal/history"
+	"github.com/bssm-oss/ganbatte/internal/history"
 )
 
 const maxLogSize = 10 * 1024 * 1024 // 10 MB

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 )
 
 // ItemType represents the type of a list item.
 type ItemType int
 
 const (
-	AliasItem    ItemType = iota
+	AliasItem ItemType = iota
 	WorkflowItem
 )
 
@@ -27,13 +27,13 @@ const (
 type Item struct {
 	Name        string
 	Type        ItemType
-	Command     string   // for aliases
-	Description string   // for workflows
+	Command     string // for aliases
+	Description string // for workflows
 	Steps       []config.Step
 	Params      []string
 	Tags        []string
-	Confirm     bool     // for aliases with confirm guard
-	Scope       Scope    // global or project
+	Confirm     bool  // for aliases with confirm guard
+	Scope       Scope // global or project
 }
 
 // Title returns the display title.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -42,7 +42,7 @@ type Model struct {
 	keys          KeyMap
 
 	// Set when user selects an item
-	SelectedItem *Item
+	SelectedItem   *Item
 	SelectedAction Action
 	Quitting       bool
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/justn-hyeok/ganbatte/internal/config"
+	"github.com/bssm-oss/ganbatte/internal/config"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 )

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/justn-hyeok/ganbatte/cmd"
+	"github.com/bssm-oss/ganbatte/cmd"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Change the Go module and internal imports to the public `github.com/bssm-oss/ganbatte` path so `go install github.com/bssm-oss/ganbatte@latest` can resolve.
- Remove the duplicate Homebrew cask completion argument that caused `gnb completion completion <shell>` warnings.
- Update README and repository metadata links to the public org path.

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run`
- `goreleaser check`
- `goreleaser release --snapshot --clean`

## Release follow-up
After merge, cut `v1.5.5` and re-run the real consumer checks:
- release checksum verification
- clean artifact smoke
- `go install github.com/bssm-oss/ganbatte@v1.5.5`
- Homebrew cask install without completion warnings