### PR TITLE
Fix consumer install smoke issues

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ homebrew_casks:
     description: "Workflow/shortcut management CLI for lazy developers"
     directory: Casks
     generate_completions_from_executable:
-      executable: "bin/gnb"
+      executable: "gnb"
       shell_parameter_format: cobra
       shells:
         - bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Project config discovery now walks parent directories, so `.ganbatte.*` works from nested repo paths.
 
 ### Fixed
+- Go install documentation now uses the `cmd/gnb` package so the installed binary is named `gnb`.
+- Homebrew cask completion generation now invokes the installed `gnb` binary directly.
 - Go module path now matches the public `bssm-oss/ganbatte` repository, so `go install github.com/bssm-oss/ganbatte@latest` works.
 - Homebrew cask completion generation no longer passes a duplicate `completion` argument.
 - `gnb run` and `gnb show` now use merged global/project config, matching `gnb list` behavior.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 brew install --cask bssm-oss/tap/ganbatte
 
 # Go install (macOS / Linux)
-go install github.com/bssm-oss/ganbatte@latest
+go install github.com/bssm-oss/ganbatte/cmd/gnb@latest
 
 # 로컬 빌드
 git clone https://github.com/bssm-oss/ganbatte.git

--- a/cmd/gnb/main.go
+++ b/cmd/gnb/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+
+	"github.com/bssm-oss/ganbatte/cmd"
+)
+
+func main() {
+	cmd.RootCmd.SetOut(os.Stdout)
+	if err := cmd.RootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `cmd/gnb` as an installable main package so `go install github.com/bssm-oss/ganbatte/cmd/gnb@latest` produces a `gnb` binary.
- Update README to use the installable `cmd/gnb` path.
- Change Homebrew cask completion generation to invoke `gnb` directly instead of `bin/gnb`.

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run`
- `goreleaser check`
- `goreleaser release --snapshot --clean`
- `go build -o /tmp/gnb-cmd ./cmd/gnb`