### PR TITLE
docs: reposition around history-to-workflow

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,19 +2,27 @@
 
 [English](./README.md) | [명령어 레퍼런스](./docs/man) | [스펙](./docs/spec.md) | [릴리즈](https://github.com/bssm-oss/ganbatte/releases)
 
-> lazy developers를 위한 워크플로우/단축어 관리 CLI. 頑張って!
+> 내 shell history가 이미 알고 있는 반복 작업을 alias/workflow로 바꿔주는 CLI.
 
-`ganbatte`는 흩어진 shell alias와 반복 명령 시퀀스를 **이식 가능하고, 검색 가능하고, 프로젝트 스코프를 이해하는 CLI**로 정리해준다. shell alias의 빠른 사용감은 유지하면서, 파라미터, 위험 명령 확인, workflow, 히스토리 기반 추천을 더한다.
+내 `.zshrc`는 단축어를 알고 있다. 내 shell history는 습관을 알고 있다. 내 프로젝트는 workflow를 알고 있다.
+
+`ganbatte`는 이 셋을 한 곳에 모은다. 기존 alias를 가져오고, 반복 명령을 찾고, 명령 시퀀스를 재사용 가능한 workflow로 승격시키는 로컬 command hub다.
 
 ```bash
-gnb add gs "git status -sb"
-eval "$(gnb shell-init)"
-gs
+brew install --cask bssm-oss/tap/ganbatte
+
+gnb suggest   # 반복 명령과 workflow 후보 찾기
+gnb migrate   # 기존 shell alias 가져오기
+gnb           # TUI에서 전부 탐색하고 실행
 ```
+
+![ganbatte TUI demo](docs/demo/tui.gif)
 
 ## 왜 만들었나
 
-shell alias는 빠르지만 많아질수록 dotfile 더미가 된다. make, just, task는 프로젝트 빌드 태스크에는 좋지만 개인 단축어, cross-shell alias 관리, 히스토리 기반 추천에는 맞지 않는다.
+shell alias는 빠르지만 많아질수록 `.zshrc`가 alias 공동묘지가 된다. make, just, task는 프로젝트 빌드 태스크에는 좋지만 개인 단축어, cross-shell alias 관리, 히스토리 기반 추천에는 맞지 않는다.
+
+Atuin이 내가 입력한 history를 기억한다면, `ganbatte`는 반복해서 입력한 history를 내가 계속 쓸 수 있는 명령으로 바꾼다.
 
 `gnb`는 그 중간 지점에 있다.
 
@@ -30,7 +38,45 @@ shell alias는 빠르지만 많아질수록 dotfile 더미가 된다. make, just
 
 ## 킬러 피처
 
-### 1. 기존 shell alias 마이그레이션
+### 1. 실제 사용 기록 기반 추천
+
+`gnb shell-init`을 켜면 명령 실행 기록을 `~/.local/share/ganbatte/track.log`에 가볍게 기록할 수 있다. 이때 매 명령마다 `gnb` 바이너리를 띄우지 않고 shell built-in으로 append하므로 레이턴시가 거의 없다.
+
+`gnb suggest`는 shell history 또는 track log를 분석해 alias, 파라미터 alias, workflow 후보를 추천한다.
+
+```bash
+gnb suggest
+gnb suggest --apply
+gnb suggest --from-history
+```
+
+```text
+$ gnb suggest
+Analyzing ganbatte track log (/Users/you/.local/share/ganbatte/track.log) (312 entries)...
+
+=== Alias Suggestions ===
+  1. c = claude
+     Used 5 times · saves ~25 keystrokes
+
+=== Parameterized Alias Suggestions ===
+  1. gcl(repo) -> git clone {repo}
+     Pattern 'git clone <...>' used 25 times with 25 variants
+
+=== Workflow Suggestions ===
+  1. git-add
+     Step 1: git add .
+     Step 2: git commit -m "update"
+     Step 3: git push
+     Sequence appeared 7 times
+
+Applying all suggestions would save ~89 keystrokes based on your history.
+```
+
+추천은 단순 빈도가 아니라 예상 키 입력 절약량 기준으로 정렬된다. `--apply` 중 파괴적 명령이 감지되면 자동으로 `confirm = true`가 붙는다.
+
+![gnb suggest demo](docs/demo/suggest.gif)
+
+### 2. 기존 shell alias 마이그레이션
 
 `.zshrc`, `.bashrc`, `.bash_aliases`, fish 설정에 흩어진 alias를 `ganbatte` 설정으로 가져온다.
 
@@ -55,19 +101,17 @@ Found 8 aliases in /Users/you/.bash_aliases
 Import all? [Y/n] y
 ```
 
-### 2. 실제 사용 기록 기반 추천
+![gnb migrate demo](docs/demo/migrate.gif)
 
-`gnb shell-init`을 켜면 명령 실행 기록을 `~/.local/share/ganbatte/track.log`에 가볍게 기록할 수 있다. 이때 매 명령마다 `gnb` 바이너리를 띄우지 않고 shell built-in으로 append하므로 레이턴시가 거의 없다.
+### 3. TUI에서 전부 탐색
 
-`gnb suggest`는 shell history 또는 track log를 분석해 alias, 파라미터 alias, workflow 후보를 추천한다.
+인자 없이 `gnb`를 실행하면 command hub가 열린다. alias와 workflow를 fuzzy search로 찾고, preview를 보고, tag와 global/project 라벨로 구분할 수 있다.
 
-```bash
-gnb suggest
-gnb suggest --apply
-gnb suggest --from-history
-```
+![ganbatte TUI demo](docs/demo/tui.gif)
 
-추천은 단순 빈도가 아니라 예상 키 입력 절약량 기준으로 정렬된다. `--apply` 중 파괴적 명령이 감지되면 자동으로 `confirm = true`가 붙는다.
+## Privacy
+
+`gnb suggest`는 로컬 shell history 파일과 로컬 ganbatte track log만 분석한다. 서버로 전송하는 데이터는 없고, telemetry, 계정, cloud sync, AI 명령 생성도 없다.
 
 ## 설치
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,27 @@
 
 [한국어](./README.ko.md) | [Command reference](./docs/man) | [Specification](./docs/spec.md) | [Releases](https://github.com/bssm-oss/ganbatte/releases)
 
-> Workflow and shortcut management for lazy developers. 頑張って!
+> Your shell history knows what you repeat. ganbatte turns it into aliases and workflows.
 
-`ganbatte` turns scattered shell aliases and repeated command sequences into a portable, searchable, project-aware CLI. It keeps the speed of shell aliases, adds guardrails and workflows, and mines your history for shortcuts you would actually use.
+Your `.zshrc` knows your shortcuts. Your shell history knows your habits. Your project knows its workflows.
+
+`ganbatte` puts them in one place: a local command hub for migrating aliases, mining repeated commands, and promoting command sequences into reusable workflows.
 
 ```bash
-gnb add gs "git status -sb"
-eval "$(gnb shell-init)"
-gs
+brew install --cask bssm-oss/tap/ganbatte
+
+gnb suggest   # find repeated commands and workflow candidates
+gnb migrate   # import existing shell aliases
+gnb           # browse everything in a TUI
 ```
+
+![ganbatte TUI demo](docs/demo/tui.gif)
 
 ## Why It Exists
 
-Shell aliases are fast until they become a pile of hand-edited dotfiles. Make, just, and task are great for project build tasks, but they are not designed for personal command shortcuts, cross-shell alias migration, or history-driven recommendations.
+Shell aliases are fast until your `.zshrc` becomes an alias graveyard. Make, just, and task are great for project build tasks, but they are not designed for personal command shortcuts, cross-shell alias migration, or history-driven recommendations.
+
+Atuin remembers what you typed. `ganbatte` turns what you repeat into commands you can keep.
 
 `gnb` sits in the middle:
 
@@ -30,7 +38,43 @@ Shell aliases are fast until they become a pile of hand-edited dotfiles. Make, j
 
 ## Killer Features
 
-### 1. Migrate Existing Shell Aliases
+### 1. Suggest Shortcuts From Real Usage
+
+`gnb shell-init` can passively append command history to `~/.local/share/ganbatte/track.log` without spawning the `gnb` binary for every command. `gnb suggest` then uses shell history or the track log to recommend aliases, parameterized aliases, and workflows.
+
+```bash
+gnb suggest
+gnb suggest --apply
+gnb suggest --from-history
+```
+
+```text
+$ gnb suggest
+Analyzing ganbatte track log (/Users/you/.local/share/ganbatte/track.log) (312 entries)...
+
+=== Alias Suggestions ===
+  1. c = claude
+     Used 5 times · saves ~25 keystrokes
+
+=== Parameterized Alias Suggestions ===
+  1. gcl(repo) -> git clone {repo}
+     Pattern 'git clone <...>' used 25 times with 25 variants
+
+=== Workflow Suggestions ===
+  1. git-add
+     Step 1: git add .
+     Step 2: git commit -m "update"
+     Step 3: git push
+     Sequence appeared 7 times
+
+Applying all suggestions would save ~89 keystrokes based on your history.
+```
+
+Suggestions are ranked by estimated keystrokes saved, not just raw frequency. Destructive commands detected during `--apply` are marked with `confirm = true`.
+
+![gnb suggest demo](docs/demo/suggest.gif)
+
+### 2. Migrate Existing Shell Aliases
 
 Bring your current `.zshrc`, `.bashrc`, `.bash_aliases`, or fish aliases into one managed config.
 
@@ -55,17 +99,17 @@ Found 8 aliases in /Users/you/.bash_aliases
 Import all? [Y/n] y
 ```
 
-### 2. Suggest Shortcuts From Real Usage
+![gnb migrate demo](docs/demo/migrate.gif)
 
-`gnb shell-init` can passively append command history to `~/.local/share/ganbatte/track.log` without spawning the `gnb` binary for every command. `gnb suggest` then uses shell history or the track log to recommend aliases, parameterized aliases, and workflows.
+### 3. Browse Everything in a TUI
 
-```bash
-gnb suggest
-gnb suggest --apply
-gnb suggest --from-history
-```
+Run `gnb` with no arguments to open the command hub: fuzzy search, preview, tags, and global/project labels for every alias and workflow.
 
-Suggestions are ranked by estimated keystrokes saved, not just raw frequency. Destructive commands detected during `--apply` are marked with `confirm = true`.
+![ganbatte TUI demo](docs/demo/tui.gif)
+
+## Privacy
+
+`gnb suggest` analyzes local shell history files and the local ganbatte track log. Nothing is sent to a server, and ganbatte has no telemetry, account, cloud sync, or AI command generation.
 
 ## Install
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This directory contains the longer-form documentation for `ganbatte` (`gnb`). Start with the root [README](../README.md) for the product overview, then use these files when you need details.
+This directory contains the longer-form documentation for `ganbatte` (`gnb`), a local CLI that turns repeated shell history into aliases and workflows. Start with the root [README](../README.md) for the product overview, then use these files when you need details.
 
 ## Documents
 
@@ -26,6 +26,16 @@ or:
 go install github.com/bssm-oss/ganbatte/cmd/gnb@latest
 gnb doctor
 ```
+
+### Analyze Repeated Commands
+
+```bash
+gnb suggest
+gnb suggest --from-history
+gnb suggest --apply
+```
+
+`gnb suggest` reads local shell history and the local ganbatte track log only. It does not send command history to a server.
 
 ### Generate Man Pages
 


### PR DESCRIPTION
## Summary
- Repositions ganbatte around turning repeated shell history into aliases and workflows.
- Moves `gnb suggest` to the top of the README flow with concrete saved-keystrokes examples and demo GIFs.
- Adds a concise privacy note and repeated-command entry in the docs index.

## Verification
- go test ./...
- gh repo view bssm-oss/ganbatte --json description,repositoryTopics