### PR TITLE
fix(release): publish Homebrew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,23 +23,19 @@ archives:
       - goos: windows
         formats: [zip]
 
-homebrew_casks:
+brews:
   - repository:
       owner: bssm-oss
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    binaries:
-      - gnb
     homepage: https://github.com/bssm-oss/ganbatte
     description: "Workflow/shortcut management CLI for lazy developers"
-    directory: Casks
-    generate_completions_from_executable:
-      executable: "gnb"
-      shell_parameter_format: cobra
-      shells:
-        - bash
-        - zsh
-        - fish
+    license: MIT
+    install: |
+      bin.install "gnb"
+      generate_completions_from_executable(bin/"gnb", "completion")
+    test: |
+      system "#{bin}/gnb", "--help"
 
 checksum:
   name_template: checksums.txt

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 `ganbatte`는 이 셋을 한 곳에 모은다. 기존 alias를 가져오고, 반복 명령을 찾고, 명령 시퀀스를 재사용 가능한 workflow로 승격시키는 로컬 command hub다.
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 
 gnb suggest   # 반복 명령과 workflow 후보 찾기
 gnb migrate   # 기존 shell alias 가져오기
@@ -118,7 +118,7 @@ Import all? [Y/n] y
 ### Homebrew
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 ```
 
 ### Go

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Your `.zshrc` knows your shortcuts. Your shell history knows your habits. Your p
 `ganbatte` puts them in one place: a local command hub for migrating aliases, mining repeated commands, and promoting command sequences into reusable workflows.
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 
 gnb suggest   # find repeated commands and workflow candidates
 gnb migrate   # import existing shell aliases
@@ -116,7 +116,7 @@ Run `gnb` with no arguments to open the command hub: fuzzy search, preview, tags
 ### Homebrew
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 ```
 
 ### Go

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ This directory contains the longer-form documentation for `ganbatte` (`gnb`), a 
 ### Install and Verify
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 gnb doctor
 gnb --help
 ```
@@ -60,7 +60,7 @@ Before calling a release done, verify at least one clean consumer path:
 
 ```bash
 go install github.com/bssm-oss/ganbatte/cmd/gnb@<version>
-brew install --cask bssm-oss/tap/ganbatte --force
+brew reinstall bssm-oss/tap/ganbatte
 ```
 
 ## Configuration Files


### PR DESCRIPTION
## Summary
- Switch GoReleaser back to publishing a Homebrew formula for `gnb`.
- Update README install commands to use `brew install bssm-oss/tap/ganbatte`.

## Verification
- go test ./...
- goreleaser check
- goreleaser release --snapshot --clean
- brew install bssm-oss/tap/ganbatte
- brew test bssm-oss/tap/ganbatte