### PR TITLE
fix: prepare release readiness checks

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ archives:
       - goos: windows
         formats: [zip]
 
-homebrew_casks:
+brews:
   - repository:
       owner: bssm-oss
       name: homebrew-tap
@@ -31,13 +31,11 @@ homebrew_casks:
     homepage: https://github.com/bssm-oss/ganbatte
     description: "Workflow/shortcut management CLI for lazy developers"
     license: MIT
-    binaries:
-      - gnb
-    generate_completions_from_executable:
-      executable: "bin/gnb"
-      args:
-        - completion
-      shell_parameter_format: cobra
+    install: |
+      bin.install "gnb"
+      generate_completions_from_executable(bin/"gnb", "completion")
+    test: |
+      system "#{bin}/gnb", "--help"
 
 checksum:
   name_template: checksums.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ archives:
       - goos: windows
         formats: [zip]
 
-brews:
+homebrew_casks:
   - repository:
       owner: bssm-oss
       name: homebrew-tap
@@ -31,11 +31,13 @@ brews:
     homepage: https://github.com/bssm-oss/ganbatte
     description: "Workflow/shortcut management CLI for lazy developers"
     license: MIT
-    install: |
-      bin.install "gnb"
-      generate_completions_from_executable(bin/"gnb", "completion")
-    test: |
-      system "#{bin}/gnb", "--help"
+    binaries:
+      - gnb
+    generate_completions_from_executable:
+      executable: "bin/gnb"
+      args:
+        - completion
+      shell_parameter_format: cobra
 
 checksum:
   name_template: checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Go install documentation now uses the `cmd/gnb` package so the installed binary is named `gnb`.
-- Homebrew cask completion generation now invokes the installed `gnb` binary directly.
+- Homebrew formula completion generation now invokes the installed `gnb` binary directly.
 - Go module path now matches the public `bssm-oss/ganbatte` repository, so `go install github.com/bssm-oss/ganbatte@latest` works.
-- Homebrew cask completion generation no longer passes a duplicate `completion` argument.
+- Homebrew formula completion generation no longer passes a duplicate `completion` argument.
 - `gnb run` and `gnb show` now use merged global/project config, matching `gnb list` behavior.
 - `gnb run` now asks for confirmation when a project item overrides a global item unless `--yes` is used.
 - Release workflow now passes the Homebrew tap token using the environment variable expected by GoReleaser.
+- Release documentation now records why Homebrew formula publishing stays on GoReleaser `brews` despite the v2 deprecation warning.
 - Release workflow now validates manual dispatch tags and runs tests before publishing tokens are injected.
 - CI lint issues reported by golangci-lint v1.64.8.
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -63,7 +63,7 @@ testdata/fixtures/      Shell history samples, config format examples
 ## CI/CD
 
 - GitHub Actions: test (ubuntu/macos/windows) + lint (golangci-lint)
-- goreleaser: multi-OS binaries + Homebrew tap (`justn-hyeok/homebrew-tap`)
+- goreleaser: multi-OS binaries + Homebrew formula tap (`bssm-oss/homebrew-tap`)
 - All tests use `shell: bash` on Windows to avoid PowerShell parsing issues
 
 ## Test Coverage

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 `ganbatte`는 이 셋을 한 곳에 모은다. 기존 alias를 가져오고, 반복 명령을 찾고, 명령 시퀀스를 재사용 가능한 workflow로 승격시키는 로컬 command hub다.
 
 ```bash
-brew install bssm-oss/tap/ganbatte
+brew install --cask bssm-oss/tap/ganbatte
 
 gnb suggest   # 반복 명령과 workflow 후보 찾기
 gnb migrate   # 기존 shell alias 가져오기
@@ -118,7 +118,7 @@ Import all? [Y/n] y
 ### Homebrew
 
 ```bash
-brew install bssm-oss/tap/ganbatte
+brew install --cask bssm-oss/tap/ganbatte
 ```
 
 ### Go

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 `ganbatte`는 이 셋을 한 곳에 모은다. 기존 alias를 가져오고, 반복 명령을 찾고, 명령 시퀀스를 재사용 가능한 workflow로 승격시키는 로컬 command hub다.
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 
 gnb suggest   # 반복 명령과 workflow 후보 찾기
 gnb migrate   # 기존 shell alias 가져오기
@@ -118,7 +118,7 @@ Import all? [Y/n] y
 ### Homebrew
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 ```
 
 ### Go
@@ -312,7 +312,7 @@ go vet ./...
 go run cmd/gendoc.go
 ```
 
-릴리즈 빌드는 `v*` 태그 push 시 GoReleaser가 처리한다. 현재 릴리즈는 GitHub release archive, `go install github.com/bssm-oss/ganbatte/cmd/gnb@v1.5.6`, Homebrew Cask 경로로 실제 설치 검증을 마쳤다.
+릴리즈 빌드는 `v*` 태그 push 시 GoReleaser가 처리한다. 현재 릴리즈는 GitHub release archive, `go install github.com/bssm-oss/ganbatte/cmd/gnb@v1.5.6`, Homebrew formula 경로로 실제 설치 검증을 마쳤다.
 
 ## 하지 않는 것
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Your `.zshrc` knows your shortcuts. Your shell history knows your habits. Your p
 `ganbatte` puts them in one place: a local command hub for migrating aliases, mining repeated commands, and promoting command sequences into reusable workflows.
 
 ```bash
-brew install bssm-oss/tap/ganbatte
+brew install --cask bssm-oss/tap/ganbatte
 
 gnb suggest   # find repeated commands and workflow candidates
 gnb migrate   # import existing shell aliases
@@ -116,7 +116,7 @@ Run `gnb` with no arguments to open the command hub: fuzzy search, preview, tags
 ### Homebrew
 
 ```bash
-brew install bssm-oss/tap/ganbatte
+brew install --cask bssm-oss/tap/ganbatte
 ```
 
 ### Go

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Your `.zshrc` knows your shortcuts. Your shell history knows your habits. Your p
 `ganbatte` puts them in one place: a local command hub for migrating aliases, mining repeated commands, and promoting command sequences into reusable workflows.
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 
 gnb suggest   # find repeated commands and workflow candidates
 gnb migrate   # import existing shell aliases
@@ -116,7 +116,7 @@ Run `gnb` with no arguments to open the command hub: fuzzy search, preview, tags
 ### Homebrew
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 ```
 
 ### Go
@@ -310,7 +310,7 @@ go vet ./...
 go run cmd/gendoc.go
 ```
 
-Release builds are handled by GoReleaser on pushed `v*` tags. Consumer paths verified for the current release include GitHub release archives, `go install github.com/bssm-oss/ganbatte/cmd/gnb@v1.5.6`, and Homebrew Cask.
+Release builds are handled by GoReleaser on pushed `v*` tags. Consumer paths verified for the current release include GitHub release archives, `go install github.com/bssm-oss/ganbatte/cmd/gnb@v1.5.6`, and the Homebrew formula.
 
 ## Non-Goals
 

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -36,6 +36,7 @@ func executeCmd(args ...string) (string, error) {
 	_ = initCmd.Flags().Set("format", "")
 	_ = initCmd.Flags().Set("project", "false")
 	_ = shellInitCmd.Flags().Set("shell", "")
+	_ = doctorCmd.Flags().Set("fix", "false")
 	err := RootCmd.Execute()
 	return buf.String(), err
 }
@@ -522,6 +523,31 @@ func TestDoctorCommand(t *testing.T) {
 	assert.Contains(t, out, "[OK] Global config:")
 }
 
+func TestDoctorDoesNotSuggestFixForNonRepairableIssues(t *testing.T) {
+	setupTestHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+	_, _ = executeCmd("init", "--format", "toml")
+
+	out, err := executeCmd("doctor")
+	require.NoError(t, err)
+	assert.Contains(t, out, "History file not found")
+	assert.NotContains(t, out, "automatically fix repairable issues")
+}
+
+func TestDoctorSuggestsFixForRepairableIssues(t *testing.T) {
+	home := setupTestHome(t)
+	t.Setenv("SHELL", "/bin/zsh")
+	_, _ = executeCmd("init", "--format", "toml")
+
+	duplicateConfig := filepath.Join(home, ".config", "ganbatte", "config.yaml")
+	require.NoError(t, os.WriteFile(duplicateConfig, []byte("version: \"1.0.0\"\n"), 0o644))
+
+	out, err := executeCmd("doctor")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Multiple config files found")
+	assert.Contains(t, out, "automatically fix repairable issues")
+}
+
 // --- config path ---
 
 func TestConfigPath(t *testing.T) {
@@ -629,6 +655,25 @@ func TestRootCommand(t *testing.T) {
 	out, err := executeCmd()
 	require.NoError(t, err)
 	assert.Contains(t, out, "No aliases or workflows configured")
+}
 
-	// With config + items: would launch TUI (can't test interactive TUI here)
+func TestRootCommandNonTTYWithItems(t *testing.T) {
+	setupTestHome(t)
+	_, _ = executeCmd("init", "--format", "toml")
+	_, _ = executeCmd("add", "gs", "git status -sb")
+
+	oldStdin := os.Stdin
+	readEnd, writeEnd, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() {
+		os.Stdin = oldStdin
+		readEnd.Close()
+	}()
+	require.NoError(t, writeEnd.Close())
+	os.Stdin = readEnd
+
+	_, err = executeCmd()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TUI requires an interactive terminal")
+	assert.NotContains(t, err.Error(), "/dev/tty")
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -21,6 +21,7 @@ var doctorCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fix, _ := cmd.Flags().GetBool("fix")
 		issues := 0
+		repairableIssues := 0
 
 		// 1. Shell detection
 		sh := shell.Detect()
@@ -65,6 +66,7 @@ var doctorCmd = &cobra.Command{
 		case 1:
 			cmd.Printf("[OK] Global config: %s\n", foundConfigs[0])
 		default:
+			repairableIssues++
 			cmd.Printf("[WARN] Multiple config files found — only %s is used\n", foundConfigs[0])
 			for _, p := range foundConfigs[1:] {
 				cmd.Printf("       ignored: %s\n", p)
@@ -160,6 +162,7 @@ var doctorCmd = &cobra.Command{
 			cmd.Println("=== Shell Integration ===")
 			if checkP10kOrdering(cmd, home, fix) {
 				issues++
+				repairableIssues++
 			} else {
 				p10kPresent := func() bool {
 					data, err := os.ReadFile(filepath.Join(home, ".zshrc"))
@@ -184,7 +187,7 @@ var doctorCmd = &cobra.Command{
 			cmd.Println("No issues found. ganbatte!")
 		} else {
 			cmd.Printf("%d issue(s) found\n", issues)
-			if !fix {
+			if !fix && repairableIssues > 0 {
 				cmd.Println("Run 'gnb doctor --fix' to automatically fix repairable issues")
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,10 @@ var RootCmd = &cobra.Command{
 			return nil
 		}
 
+		if !isInteractiveTerminal(os.Stdin) {
+			return fmt.Errorf("TUI requires an interactive terminal; use 'gnb list' or 'gnb run <name>' in scripts")
+		}
+
 		m := tui.New(items)
 		p := tea.NewProgram(m, tea.WithAltScreen())
 		finalModel, err := p.Run()
@@ -58,6 +62,14 @@ var RootCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func isInteractiveTerminal(file *os.File) bool {
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
 }
 
 func handleRun(scoped *config.ScopedConfig, item *tui.Item) error {

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ This directory contains the longer-form documentation for `ganbatte` (`gnb`), a 
 ### Install and Verify
 
 ```bash
-brew install --cask bssm-oss/tap/ganbatte
+brew install bssm-oss/tap/ganbatte
 gnb doctor
 gnb --help
 ```
@@ -62,6 +62,8 @@ Before calling a release done, verify at least one clean consumer path:
 go install github.com/bssm-oss/ganbatte/cmd/gnb@<version>
 brew reinstall bssm-oss/tap/ganbatte
 ```
+
+`ganbatte` intentionally publishes a Homebrew formula through GoReleaser's `brews` configuration. GoReleaser v2 may warn that `brews` is deprecated, but the official replacement (`homebrew_casks`) publishes a cask and would change the install semantics. Treat the warning as future GoReleaser v3 migration debt, not a v2 release blocker.
 
 ## Configuration Files
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ This directory contains the longer-form documentation for `ganbatte` (`gnb`), a 
 ### Install and Verify
 
 ```bash
-brew install bssm-oss/tap/ganbatte
+brew install --cask bssm-oss/tap/ganbatte
 gnb doctor
 gnb --help
 ```


### PR DESCRIPTION
## Summary
- Improve command diagnostics for non-TTY TUI usage and repairable `doctor --fix` guidance.
- Keep Homebrew publishing on the formula path and document why GoReleaser `brews` warnings are treated as v3 migration debt.
- Refresh Homebrew install and release-validation docs to match the formula-based tap.

## Verification
- go test ./...
- go test -race ./...
- go vet ./...
- golangci-lint run
- goreleaser check
- goreleaser release --snapshot --clean --skip=publish